### PR TITLE
Update navbar links to use root path

### DIFF
--- a/dist/aboutme.html
+++ b/dist/aboutme.html
@@ -35,7 +35,7 @@
     <body>
         <header class="navbar navbar-top navbar-expand-lg navbar-fixed">
             <div class="container">
-                <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                <a href="/" class="nav-link active">
                     <span class="nav-link-name title-top-black">Shehab.</span>
                 </a>
                 <a class="navbar-toggle" href="#navbar-mobile-style-2" data-fancybox data-base-class="fancybox-navbar" data-keyboard="false" data-auto-focus="false" data-touch="false" data-close-existing="true" data-small-btn="false" data-toolbar="false">
@@ -102,7 +102,7 @@
             </div>
             <div class="navbar-head">
                 <div class="container">
-                    <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                    <a href="/" class="nav-link active">
                         <span class="nav-link-name title-top-black">Shehab.</span>
                     </a>
                     <a class="navbar-toggle" href="#" data-fancybox-close>

--- a/dist/axios-page.html
+++ b/dist/axios-page.html
@@ -35,7 +35,7 @@
     <body>
         <header class="navbar navbar-top navbar-expand-lg navbar-fixed">
             <div class="container">
-                <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                <a href="/" class="nav-link active">
                     <span class="nav-link-name title-top-black">Shehab.</span>
                 </a>
                 <a class="navbar-toggle" href="#navbar-mobile-style-2" data-fancybox data-base-class="fancybox-navbar" data-keyboard="false" data-auto-focus="false" data-touch="false" data-close-existing="true" data-small-btn="false" data-toolbar="false">
@@ -102,7 +102,7 @@
             </div>
             <div class="navbar-head">
                 <div class="container">
-                    <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                    <a href="/" class="nav-link active">
                         <span class="nav-link-name title-top-black">Shehab.</span>
                     </a>
                     <a class="navbar-toggle" href="#" data-fancybox-close>

--- a/dist/prudentialdesign.html
+++ b/dist/prudentialdesign.html
@@ -35,7 +35,7 @@
     <body>
         <header class="navbar navbar-top navbar-expand-lg navbar-fixed">
             <div class="container">
-                <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                <a href="/" class="nav-link active">
                     <span class="nav-link-name title-top-black">Shehab.</span>
                 </a>
                 <a class="navbar-toggle" href="#navbar-mobile-style-2" data-fancybox data-base-class="fancybox-navbar" data-keyboard="false" data-auto-focus="false" data-touch="false" data-close-existing="true" data-small-btn="false" data-toolbar="false">
@@ -102,7 +102,7 @@
             </div>
             <div class="navbar-head">
                 <div class="container">
-                    <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                    <a href="/" class="nav-link active">
                         <span class="nav-link-name title-top-black">Shehab.</span>
                     </a>
                     <a class="navbar-toggle" href="#" data-fancybox-close>

--- a/dist/quickbooks-casestudy.html
+++ b/dist/quickbooks-casestudy.html
@@ -35,7 +35,7 @@
     <body>
         <header class="navbar navbar-top navbar-expand-lg navbar-fixed">
             <div class="container">
-                <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                <a href="/" class="nav-link active">
                     <span class="nav-link-name title-top-black">Shehab.</span>
                 </a>
                 <a class="navbar-toggle" href="#navbar-mobile-style-2" data-fancybox data-base-class="fancybox-navbar" data-keyboard="false" data-auto-focus="false" data-touch="false" data-close-existing="true" data-small-btn="false" data-toolbar="false">
@@ -102,7 +102,7 @@
             </div>
             <div class="navbar-head">
                 <div class="container">
-                    <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                    <a href="/" class="nav-link active">
                         <span class="nav-link-name title-top-black">Shehab.</span>
                     </a>
                     <a class="navbar-toggle" href="#" data-fancybox-close>

--- a/dist/wayfindingdesign.html
+++ b/dist/wayfindingdesign.html
@@ -35,7 +35,7 @@
     <body>
         <header class="navbar navbar-top navbar-expand-lg navbar-fixed">
             <div class="container">
-                <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                <a href="/" class="nav-link active">
                     <span class="nav-link-name title-top-black">Shehab.</span>
                 </a>
                 <a class="navbar-toggle" href="#navbar-mobile-style-2" data-fancybox data-base-class="fancybox-navbar" data-keyboard="false" data-auto-focus="false" data-touch="false" data-close-existing="true" data-small-btn="false" data-toolbar="false">
@@ -102,7 +102,7 @@
             </div>
             <div class="navbar-head">
                 <div class="container">
-                    <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+                    <a href="/" class="nav-link active">
                         <span class="nav-link-name title-top-black">Shehab.</span>
                     </a>
                     <a class="navbar-toggle" href="#" data-fancybox-close>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 <body class="bg-dark navbar-show" data-new-gr-c-s-check-loaded="14.1010.0" data-gr-ext-installed="" style="">
 <header class="navbar navbar-top navbar-expand-lg navbar-dark navbar-fixed">
     <div class="container">
-        <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+        <a href="/" class="nav-link active">
             <span class="nav-link-name title-top">Shehab.</span>
         </a>
         <a class="navbar-toggle order-4" href="#navbar-mobile-style-2" data-fancybox="" data-base-class="fancybox-navbar" data-keyboard="false" data-auto-focus="false" data-touch="false" data-close-existing="true" data-small-btn="false" data-toolbar="false">
@@ -104,7 +104,7 @@
     </div>
     <div class="navbar-head">
         <div class="container">
-            <a href="https://dampmulch.github.io/DesignPortfolio/" class="nav-link active">
+            <a href="/" class="nav-link active">
                 <span class="nav-link-name title-top">Shehab.</span>
             </a>
             <a class="navbar-toggle" href="#" data-fancybox-close="">


### PR DESCRIPTION
Replaced external GitHub Pages URLs in navbar links with root-relative '/' paths across all HTML files. This change improves navigation consistency and supports local development or deployment at the site root.